### PR TITLE
[#13] FestivalScreen / MoreScreen 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,7 @@
         </activity>
 
         <activity android:name=".presentation.main.MainActivity"/>
+        <activity android:name=".presentation.more.MoreActivity"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/kr/ksw/visitkorea/data/di/DataModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/di/DataModule.kt
@@ -10,10 +10,13 @@ import kr.ksw.visitkorea.data.local.databases.AreaCodeDatabase
 import kr.ksw.visitkorea.data.remote.api.AreaCodeApi
 import kr.ksw.visitkorea.data.remote.api.LocationBasedListApi
 import kr.ksw.visitkorea.data.remote.api.RetrofitInterceptor
+import kr.ksw.visitkorea.data.remote.api.SearchFestivalApi
 import kr.ksw.visitkorea.data.repository.AreaCodeRepository
 import kr.ksw.visitkorea.data.repository.AreaCodeRepositoryImpl
 import kr.ksw.visitkorea.data.repository.LocationBasedListRepository
 import kr.ksw.visitkorea.data.repository.LocationBasedListRepositoryImpl
+import kr.ksw.visitkorea.data.repository.SearchFestivalRepository
+import kr.ksw.visitkorea.data.repository.SearchFestivalRepositoryImpl
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -71,5 +74,15 @@ object DataModule {
     @Singleton
     fun provideLocationBasedListRepository(locationBasedListApi: LocationBasedListApi): LocationBasedListRepository {
         return LocationBasedListRepositoryImpl(locationBasedListApi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSearchFestivalApi(retrofit: Retrofit): SearchFestivalApi = retrofit.create(SearchFestivalApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSearchFestivalRepository(searchFestivalApi: SearchFestivalApi): SearchFestivalRepository {
+        return SearchFestivalRepositoryImpl(searchFestivalApi)
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/data/paging/source/LocationBasedPagingSource.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/paging/source/LocationBasedPagingSource.kt
@@ -37,10 +37,7 @@ class LocationBasedPagingSource (
         return LoadResult.Page(
             data = data,
             prevKey = if(page == 1 || data.isEmpty()) null else page - 1,
-            nextKey = if(data.size == loadSize &&
-                data.isNotEmpty() &&
-                page * loadSize < 100
-            ) page + 1 else null
+            nextKey = if(data.size == loadSize && data.isNotEmpty()) page + 1 else null
         )
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
@@ -1,0 +1,42 @@
+package kr.ksw.visitkorea.data.paging.source
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import kr.ksw.visitkorea.data.mapper.toItems
+import kr.ksw.visitkorea.data.remote.api.SearchFestivalApi
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+
+class SearchFestivalPagingSource(
+    private val searchFestivalApi: SearchFestivalApi,
+    private val eventStartDate: String,
+    private val eventEndDate: String,
+    private val areaCode: String?,
+    private val sigunguCode: String?
+) : PagingSource<Int, SearchFestivalDTO>() {
+
+    override fun getRefreshKey(state: PagingState<Int, SearchFestivalDTO>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            val anchorPage = state.closestPageToPosition(anchor)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, SearchFestivalDTO> {
+        val page = params.key ?: 1
+        val loadSize = params.loadSize
+        val response = searchFestivalApi.searchFestival(
+            numOfRows = loadSize,
+            pageNo =  page,
+            eventStartDate = eventStartDate,
+            eventEndDate = eventEndDate,
+            areaCode = areaCode,
+            sigunguCode = sigunguCode
+        )
+        val data = response.toItems()
+        return LoadResult.Page(
+            data = data,
+            prevKey = if(page == 1) null else page - 1,
+            nextKey = if(data.size == loadSize) page + 1 else null
+        )
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
@@ -36,7 +36,9 @@ class SearchFestivalPagingSource(
         return LoadResult.Page(
             data = data,
             prevKey = if(page == 1) null else page - 1,
-            nextKey = if(data.size == loadSize) page + 1 else null
+            nextKey = if(data.size == loadSize && page * loadSize < 50)
+                page + 1
+            else null
         )
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchFestivalPagingSource.kt
@@ -36,7 +36,7 @@ class SearchFestivalPagingSource(
         return LoadResult.Page(
             data = data,
             prevKey = if(page == 1) null else page - 1,
-            nextKey = if(data.size == loadSize && page * loadSize < 50)
+            nextKey = if(data.size == loadSize)
                 page + 1
             else null
         )

--- a/app/src/main/java/kr/ksw/visitkorea/data/remote/api/SearchFestivalApi.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/remote/api/SearchFestivalApi.kt
@@ -1,0 +1,19 @@
+package kr.ksw.visitkorea.data.remote.api
+
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+import kr.ksw.visitkorea.data.remote.model.ApiResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SearchFestivalApi {
+    @GET("searchFestival1")
+    suspend fun searchFestival(
+        @Query("arrange") arrange: String = "S",
+        @Query("numOfRows") numOfRows: Int,
+        @Query("pageNo") pageNo: Int,
+        @Query("eventStartDate") eventStartDate: String,
+        @Query("eventEndDate") eventEndDate: String,
+        @Query("areaCode") areaCode: String? = null,
+        @Query("sigunguCode") sigunguCode: String? = null
+    ): ApiResponse<SearchFestivalDTO>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/remote/dto/SearchFestivalDTO.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/remote/dto/SearchFestivalDTO.kt
@@ -1,0 +1,31 @@
+package kr.ksw.visitkorea.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class SearchFestivalDTO(
+    @SerializedName("addr1")
+    val address: String,
+    @SerializedName("areacode")
+    val areaCode: String,
+    @SerializedName("sigungucode")
+    val sigunguCode: String,
+    @SerializedName("contentid")
+    val contentId: String,
+    @SerializedName("contenttypeid")
+    val contentTypeId: String,
+    @SerializedName("eventstartdate")
+    val eventStartDate: String,
+    @SerializedName("eventenddate")
+    val eventEndDate: String,
+    @SerializedName("firstimage")
+    val firstImage: String,
+    @SerializedName("firstimage2")
+    val firstImage2: String,
+    @SerializedName("mapx")
+    val mapX: String,
+    @SerializedName("mapy")
+    val mapY: String,
+    val cat3: String,
+    val tel: String,
+    val title: String
+)

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepository.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepository.kt
@@ -1,0 +1,14 @@
+package kr.ksw.visitkorea.data.repository
+
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+
+interface SearchFestivalRepository {
+    suspend operator fun invoke(
+        numOfRows: Int,
+        pageNo: Int,
+        eventStartDate: String,
+        eventEndDate: String,
+        areaCode: String? = null,
+        sigunguCode: String? = null
+    ): Result<List<SearchFestivalDTO>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepositoryImpl.kt
@@ -1,0 +1,28 @@
+package kr.ksw.visitkorea.data.repository
+
+import kr.ksw.visitkorea.data.mapper.toItems
+import kr.ksw.visitkorea.data.remote.api.SearchFestivalApi
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+import javax.inject.Inject
+
+class SearchFestivalRepositoryImpl @Inject constructor(
+    private val searchFestivalApi: SearchFestivalApi
+): SearchFestivalRepository {
+    override suspend fun invoke(
+        numOfRows: Int,
+        pageNo: Int,
+        eventStartDate: String,
+        eventEndDate: String,
+        areaCode: String?,
+        sigunguCode: String?
+    ): Result<List<SearchFestivalDTO>> = runCatching {
+        searchFestivalApi.searchFestival(
+            numOfRows = numOfRows,
+            pageNo = pageNo,
+            eventStartDate = eventStartDate,
+            eventEndDate = eventEndDate,
+            areaCode = areaCode,
+            sigunguCode = sigunguCode
+        ).toItems()
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/di/FestivalModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/di/FestivalModule.kt
@@ -1,0 +1,15 @@
+package kr.ksw.visitkorea.domain.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import kr.ksw.visitkorea.domain.usecase.festival.GetFestivalListUseCase
+import kr.ksw.visitkorea.domain.usecase.festival.GetFestivalListUseCaseImpl
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+abstract class FestivalModule {
+    @Binds
+    abstract fun bindGetFestivalListUseCase(getFestivalListUseCase: GetFestivalListUseCaseImpl): GetFestivalListUseCase
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/di/MoreModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/di/MoreModule.kt
@@ -1,0 +1,17 @@
+package kr.ksw.visitkorea.domain.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import kr.ksw.visitkorea.domain.usecase.more.GetMoreListUseCase
+import kr.ksw.visitkorea.domain.usecase.more.GetMoreListUseCaseImpl
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+abstract class MoreModule {
+    @Binds
+    abstract fun bindGetMoreListUseCase(
+        getMoreListUseCase: GetMoreListUseCaseImpl
+    ): GetMoreListUseCase
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCase.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCase.kt
@@ -1,0 +1,15 @@
+package kr.ksw.visitkorea.domain.usecase.festival
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+
+interface GetFestivalListUseCase {
+    suspend operator fun invoke(
+        forceFetch: Boolean,
+        eventStartDate: String,
+        eventEndDate: String,
+        areaCode: String?,
+        sigunguCode: String?
+    ) : Result<Flow<PagingData<SearchFestivalDTO>>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCaseImpl.kt
@@ -1,0 +1,48 @@
+package kr.ksw.visitkorea.domain.usecase.festival
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.paging.source.SearchFestivalPagingSource
+import kr.ksw.visitkorea.data.remote.api.SearchFestivalApi
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
+import javax.inject.Inject
+
+class GetFestivalListUseCaseImpl @Inject constructor(
+    private val searchFestivalApi: SearchFestivalApi
+) : GetFestivalListUseCase {
+    private var pagingSource: PagingSource<Int, SearchFestivalDTO>? = null
+
+    override suspend fun invoke(
+        forceFetch: Boolean,
+        eventStartDate: String,
+        eventEndDate: String,
+        areaCode: String?,
+        sigunguCode: String?
+    ): Result<Flow<PagingData<SearchFestivalDTO>>> = runCatching {
+        if(forceFetch &&
+            pagingSource != null &&
+            pagingSource?.invalid != true) {
+            pagingSource?.invalidate()
+        }
+        Pager(
+            config = PagingConfig(
+                pageSize = 10,
+                initialLoadSize = 10
+            ),
+            pagingSourceFactory = {
+                SearchFestivalPagingSource(
+                    searchFestivalApi,
+                    eventStartDate,
+                    eventEndDate,
+                    areaCode,
+                    sigunguCode
+                ).also {
+                    pagingSource = it
+                }
+            }
+        ).flow
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/festival/GetFestivalListUseCaseImpl.kt
@@ -29,8 +29,8 @@ class GetFestivalListUseCaseImpl @Inject constructor(
         }
         Pager(
             config = PagingConfig(
-                pageSize = 10,
-                initialLoadSize = 10
+                pageSize = 20,
+                initialLoadSize = 20
             ),
             pagingSourceFactory = {
                 SearchFestivalPagingSource(

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/hotel/GetHotelListUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/hotel/GetHotelListUseCaseImpl.kt
@@ -27,8 +27,8 @@ class GetHotelListUseCaseImpl @Inject constructor(
         }
         Pager(
             config = PagingConfig(
-                pageSize = 10,
-                initialLoadSize = 10
+                pageSize = 30,
+                initialLoadSize = 30
             ),
             pagingSourceFactory = {
                 LocationBasedPagingSource(

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/mapper/ToPresentationModelMapper.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/mapper/ToPresentationModelMapper.kt
@@ -4,6 +4,7 @@ import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
 import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
 import kr.ksw.visitkorea.domain.usecase.model.CommonCardModel
 import kr.ksw.visitkorea.domain.usecase.model.Festival
+import kr.ksw.visitkorea.domain.usecase.model.MoreCardModel
 import kr.ksw.visitkorea.domain.usecase.model.Restaurant
 import kr.ksw.visitkorea.domain.usecase.model.TouristSpot
 import kr.ksw.visitkorea.domain.usecase.util.toDateString
@@ -51,4 +52,13 @@ fun LocationBasedDTO.toRestaurantModel(): Restaurant = Restaurant(
     firstImage.toImageUrl(),
     title,
     restaurantMap[cat3] ?: ""
+)
+
+fun LocationBasedDTO.toMoreCardModel(): MoreCardModel = MoreCardModel(
+    address,
+    firstImage.toImageUrl(),
+    title,
+    dist.toDistForUi(),
+    contentId,
+    restaurantMap[cat3]
 )

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/mapper/ToPresentationModelMapper.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/mapper/ToPresentationModelMapper.kt
@@ -1,9 +1,12 @@
 package kr.ksw.visitkorea.domain.usecase.mapper
 
 import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
 import kr.ksw.visitkorea.domain.usecase.model.CommonCardModel
+import kr.ksw.visitkorea.domain.usecase.model.Festival
 import kr.ksw.visitkorea.domain.usecase.model.Restaurant
 import kr.ksw.visitkorea.domain.usecase.model.TouristSpot
+import kr.ksw.visitkorea.domain.usecase.util.toDateString
 import kr.ksw.visitkorea.domain.usecase.util.toDistForUi
 import kr.ksw.visitkorea.domain.usecase.util.toImageUrl
 
@@ -21,6 +24,15 @@ fun LocationBasedDTO.toCommonCardModel(): CommonCardModel = CommonCardModel(
     firstImage.toImageUrl(),
     title,
     contentId
+)
+
+fun SearchFestivalDTO.toFestival(): Festival = Festival(
+    address,
+    firstImage.toImageUrl(),
+    title,
+    contentId,
+    eventStartDate.toDateString(),
+    eventEndDate.toDateString()
 )
 
 val restaurantMap = mapOf(

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/model/Festival.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/model/Festival.kt
@@ -1,0 +1,10 @@
+package kr.ksw.visitkorea.domain.usecase.model
+
+data class Festival(
+    val address: String = "",
+    val firstImage: String = "",
+    val title: String = "",
+    val contentId: String = "",
+    val eventStartDate: String = "",
+    val eventEndDate: String = ""
+)

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/model/MoreCardModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/model/MoreCardModel.kt
@@ -1,0 +1,10 @@
+package kr.ksw.visitkorea.domain.usecase.model
+
+data class MoreCardModel(
+    val address: String = "",
+    val firstImage: String = "",
+    val title: String = "",
+    val dist: String = "",
+    val contentId: String = "",
+    val category: String?,
+)

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCase.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCase.kt
@@ -1,0 +1,14 @@
+package kr.ksw.visitkorea.domain.usecase.more
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+
+interface GetMoreListUseCase {
+    suspend operator fun invoke(
+        forceFetch: Boolean,
+        mapX: String,
+        mapY: String,
+        contentTypeId: String
+    ) : Result<Flow<PagingData<LocationBasedDTO>>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCaseImpl.kt
@@ -28,8 +28,8 @@ class GetMoreListUseCaseImpl @Inject constructor(
         }
         Pager(
             config = PagingConfig(
-                pageSize = 10,
-                initialLoadSize = 10
+                pageSize = 30,
+                initialLoadSize = 30
             ),
             pagingSourceFactory = {
                 LocationBasedPagingSource(

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/more/GetMoreListUseCaseImpl.kt
@@ -1,0 +1,46 @@
+package kr.ksw.visitkorea.domain.usecase.more
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.paging.source.LocationBasedPagingSource
+import kr.ksw.visitkorea.data.remote.api.LocationBasedListApi
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+import javax.inject.Inject
+
+class GetMoreListUseCaseImpl @Inject constructor(
+    private val locationBasedListApi: LocationBasedListApi
+): GetMoreListUseCase {
+    private var pagingSource: PagingSource<Int, LocationBasedDTO>? = null
+
+    override suspend fun invoke(
+        forceFetch: Boolean,
+        mapX: String,
+        mapY: String,
+        contentTypeId: String
+    ): Result<Flow<PagingData<LocationBasedDTO>>> = runCatching {
+        if(forceFetch &&
+            pagingSource != null &&
+            pagingSource?.invalid != true) {
+            pagingSource?.invalidate()
+        }
+        Pager(
+            config = PagingConfig(
+                pageSize = 10,
+                initialLoadSize = 10
+            ),
+            pagingSourceFactory = {
+                LocationBasedPagingSource(
+                    locationBasedListApi,
+                    contentTypeId,
+                    mapX,
+                    mapY
+                ).also {
+                    pagingSource = it
+                }
+            }
+        ).flow
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/util/StringConvertUtil.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/util/StringConvertUtil.kt
@@ -10,3 +10,8 @@ fun String.toDistForUi(): String {
         "${meters[0]}m"
     }
 }
+
+fun String.toDateString(): String {
+    val sb = StringBuilder(this.substring(4))
+    return sb.insert(2, ".").toString()
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/common/ContentType.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/common/ContentType.kt
@@ -1,0 +1,14 @@
+package kr.ksw.visitkorea.presentation.common
+
+import androidx.annotation.StringRes
+import kr.ksw.visitkorea.R
+
+enum class ContentType(
+    val contentTypeId: String,
+    @StringRes val title: Int
+) {
+    TOURIST("12", R.string.tourist_spot_title),
+    CULTURE("14", R.string.culture_center_title),
+    LEiSURE("28", R.string.leisure_sports_title),
+    RESTAURANT("39", R.string.restaurant_title)
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/component/SingleLineText.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/component/SingleLineText.kt
@@ -1,12 +1,16 @@
 package kr.ksw.visitkorea.presentation.component
 
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.sp
 
 @Composable
 fun SingleLineText(
@@ -15,6 +19,7 @@ fun SingleLineText(
     fontSize: TextUnit,
     fontWeight: FontWeight = FontWeight.Normal,
     color: Color = Color.Black,
+    style: TextStyle = LocalTextStyle.current
 ) {
     Text(
         modifier = modifier,
@@ -23,6 +28,7 @@ fun SingleLineText(
         fontWeight = fontWeight,
         color = color,
         maxLines = 1,
-        overflow = TextOverflow.Ellipsis
+        overflow = TextOverflow.Ellipsis,
+        style = style
     )
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/component/FestivalCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/component/FestivalCard.kt
@@ -1,0 +1,169 @@
+package kr.ksw.visitkorea.presentation.festival.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size
+import kr.ksw.visitkorea.domain.usecase.model.Festival
+import kr.ksw.visitkorea.presentation.component.SingleLineText
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@Composable
+fun FestivalCard(
+    festival: Festival
+) {
+    Card(
+        shape = RoundedCornerShape(24.dp),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 6.dp
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .background(Color.White)
+                .padding(
+                    top = 8.dp,
+                    start = 8.dp,
+                    end = 8.dp
+                )
+        ) {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(2f)
+                    .clip(RoundedCornerShape(24.dp))
+                    .background(color = Color.LightGray),
+                model = ImageRequest
+                    .Builder(LocalContext.current)
+                    .data(festival.firstImage)
+                    .size(Size.ORIGINAL)
+                    .build(),
+                contentDescription = "Event Image",
+                contentScale = ContentScale.Crop,
+            )
+            Column(
+                modifier = Modifier
+                    .border(
+                        2.dp,
+                        Color.DarkGray,
+                        RoundedCornerShape(
+                            topStart = 24.dp,
+                            bottomEnd = 24.dp
+                        )
+                    )
+                    .background(
+                        Color.Black.copy(alpha = 0.5f),
+                        RoundedCornerShape(
+                            topStart = 24.dp,
+                            bottomEnd = 24.dp
+                        )
+                    )
+                    .padding(
+                        vertical = 12.dp,
+                        horizontal = 10.dp
+                    ),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = festival.eventStartDate,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 18.sp,
+                    color = Color.White,
+                    letterSpacing = (-0.6).sp
+                )
+                Text(
+                    text = "~",
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 18.sp,
+                    color = Color.White,
+                )
+                Text(
+                    text = festival.eventEndDate,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 18.sp,
+                    color = Color.White,
+                    letterSpacing = (-0.6).sp
+                )
+            }
+            SingleLineText(
+                modifier = Modifier
+                    .padding(start = 16.dp, end = 16.dp, bottom = 10.dp)
+                    .align(Alignment.BottomEnd),
+                text = festival.title,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
+                color = Color.White
+            )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(
+                    top = 8.dp,
+                    start = 10.dp,
+                    end = 10.dp,
+                    bottom = 10.dp
+                ),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                modifier = Modifier
+                    .size(20.dp),
+                imageVector = Icons.Outlined.LocationOn,
+                contentDescription = null,
+            )
+            SingleLineText(
+                text = festival.address,
+                fontSize = 16.sp,
+            )
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun FestivalCardPreview() {
+    VisitKoreaTheme {
+        Surface {
+            FestivalCard(Festival(
+                "경상북도 칠곡군 동명면 남원리",
+                "",
+                "가산산성 문화유산 야행",
+                "1111",
+                "10.11",
+                "10.30"
+            ))
+        }
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/screen/FestivalScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/screen/FestivalScreen.kt
@@ -1,0 +1,114 @@
+package kr.ksw.visitkorea.presentation.festival.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.ksw.visitkorea.domain.usecase.model.Festival
+import kr.ksw.visitkorea.presentation.festival.component.FestivalCard
+import kr.ksw.visitkorea.presentation.festival.viewmodel.FestivalViewModel
+import kr.ksw.visitkorea.presentation.home.component.CultureCard
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@Composable
+fun FestivalScreen(
+    viewModel: FestivalViewModel = hiltViewModel()
+) {
+    val hotelState by viewModel.festivalState.collectAsState()
+    val lazyItem = hotelState.festivalModelFlow.collectAsLazyPagingItems()
+    FestivalScreen(
+        lazyItem
+    )
+}
+
+@Composable
+fun FestivalScreen(
+    festivals: LazyPagingItems<Festival>,
+) {
+    Surface(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(
+                    top = 20.dp,
+                    start = 16.dp,
+                    end = 16.dp,
+                    bottom = 10.dp
+                )
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    text = "축제",
+                    fontSize = 32.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+                Icon(
+                    Icons.Outlined.LocationOn,
+                    modifier = Modifier
+                        .size(32.dp),
+                    contentDescription = "Location Filter Icon"
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "진행중인 축제를 찾아보세요!",
+                fontSize = 22.sp,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                items(
+                    count = festivals.itemCount,
+                    key = { index ->
+                        festivals[index]?.contentId?.toInt() ?: index
+                    }
+                ) { index ->
+                    val festival = festivals[index]
+                    festival?.run {
+                        val model = this
+                        FestivalCard(model)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun FestivalPreview() {
+    VisitKoreaTheme {
+        FestivalScreen()
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/screen/FestivalScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/screen/FestivalScreen.kt
@@ -2,6 +2,7 @@ package kr.ksw.visitkorea.presentation.festival.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -86,6 +87,7 @@ fun FestivalScreen(
             )
             Spacer(modifier = Modifier.height(16.dp))
             LazyColumn(
+                contentPadding = PaddingValues(vertical = 16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
                 items(

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/viewmodel/FestivalState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/viewmodel/FestivalState.kt
@@ -1,0 +1,12 @@
+package kr.ksw.visitkorea.presentation.festival.viewmodel
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kr.ksw.visitkorea.domain.usecase.model.Festival
+
+@Immutable
+data class FestivalState(
+    val festivalModelFlow: Flow<PagingData<Festival>> = emptyFlow()
+)

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/viewmodel/FestivalViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/viewmodel/FestivalViewModel.kt
@@ -1,0 +1,53 @@
+package kr.ksw.visitkorea.presentation.festival.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.map
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kr.ksw.visitkorea.domain.usecase.festival.GetFestivalListUseCase
+import kr.ksw.visitkorea.domain.usecase.mapper.toFestival
+import javax.inject.Inject
+
+@HiltViewModel
+class FestivalViewModel @Inject constructor(
+    private val getFestivalListUseCase: GetFestivalListUseCase
+) : ViewModel() {
+    private val _festivalState = MutableStateFlow(FestivalState())
+    val festivalState: StateFlow<FestivalState>
+        get() = _festivalState.asStateFlow()
+
+    init {
+        getFestivalList()
+    }
+
+    private fun getFestivalList(forceFetch: Boolean = false) {
+        viewModelScope.launch {
+            val hotelListFlow = getFestivalListUseCase(
+                forceFetch,
+                "20241007",
+                "20241007",
+                null,
+                null
+            ).getOrNull()
+            if(hotelListFlow != null) {
+                val festivalModelFlow = hotelListFlow.map { pagingData ->
+                    pagingData.map {
+                        it.toFestival()
+                    }
+                }.cachedIn(viewModelScope)
+                _festivalState.update {
+                    it.copy(
+                        festivalModelFlow = festivalModelFlow
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/CultureCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/CultureCard.kt
@@ -35,14 +35,13 @@ import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 @Composable
 fun CultureCard(
     modifier: Modifier = Modifier,
-    ratio: Float = 0.7f,
     title: String,
     address: String,
     image: String,
 ) {
     Card (
         modifier = modifier
-            .aspectRatio(ratio),
+            .aspectRatio(0.7f),
         shape = RoundedCornerShape(24.dp),
         elevation = CardDefaults.elevatedCardElevation(
             defaultElevation = 4.dp

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/CultureCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/CultureCard.kt
@@ -1,13 +1,14 @@
-package kr.ksw.visitkorea.presentation.home.screen
+package kr.ksw.visitkorea.presentation.home.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.LocationOn
@@ -15,11 +16,9 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -34,29 +33,26 @@ import kr.ksw.visitkorea.presentation.component.SingleLineText
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
 @Composable
-fun RestaurantCard(
+fun CultureCard(
+    modifier: Modifier = Modifier,
+    ratio: Float = 0.7f,
     title: String,
     address: String,
-    dist: String,
-    category: String,
     image: String,
 ) {
-    Card(
-        modifier = Modifier
-            .width(300.dp),
-        elevation = CardDefaults.elevatedCardElevation(6.dp),
+    Card (
+        modifier = modifier
+            .aspectRatio(ratio),
+        shape = RoundedCornerShape(24.dp),
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = 4.dp
+        )
     ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(Color.White)
-                .padding(10.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
+        Column {
             AsyncImage(
                 modifier = Modifier
-                    .size(88.dp)
-                    .clip(RoundedCornerShape(16.dp))
+                    .fillMaxWidth()
+                    .aspectRatio(1f)
                     .background(color = Color.LightGray),
                 model = ImageRequest
                     .Builder(LocalContext.current)
@@ -68,23 +64,17 @@ fun RestaurantCard(
             )
             Column(
                 modifier = Modifier
-                    .padding(start = 8.dp)
+                    .fillMaxSize()
+                    .background(Color.White)
+                    .padding(horizontal = 8.dp),
+                verticalArrangement = Arrangement.Center
             ) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    SingleLineText(
-                        text = title,
-                        fontSize = 16.sp,
-                        fontWeight = FontWeight.Medium
-                    )
-                    Text(
-                        text = category,
-                        fontSize = 14.sp,
-                        color = Color.Gray
-                    )
-                }
+                SingleLineText(
+                    modifier = Modifier.padding(start = 2.dp),
+                    text = title,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium
+                )
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -96,13 +86,9 @@ fun RestaurantCard(
                     )
                     SingleLineText(
                         text = address,
-                        fontSize = 14.sp
+                        fontSize = 12.sp,
                     )
                 }
-                SingleLineText(
-                    text = dist,
-                    fontSize = 12.sp
-                )
             }
         }
     }
@@ -110,15 +96,16 @@ fun RestaurantCard(
 
 @Composable
 @Preview(showBackground = true)
-fun RestaurantCardPreview() {
+fun CultureCardPreview() {
     VisitKoreaTheme {
-        Surface {
-            RestaurantCard(
-                "음식점",
-                "음식점 주소",
-                "188m",
-                "한식",
-                "https"
+        Surface(
+            modifier = Modifier
+                .padding(20.dp)
+        ) {
+            CultureCard(
+                title = "문화시설",
+                address = "문화시설 주소",
+                image = "https://ksw"
             )
         }
     }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/MoreButton.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/MoreButton.kt
@@ -1,0 +1,40 @@
+package kr.ksw.visitkorea.presentation.home.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+
+
+@Composable
+fun MoreButton(
+    onMoreClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .clickable(onClick = onMoreClick),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "더보기",
+            fontSize = 14.sp,
+            color = Color.Gray
+        )
+        Icon(
+            Icons.AutoMirrored.Filled.KeyboardArrowRight,
+            contentDescription = "관광지 더보기",
+            modifier = Modifier
+                .size(20.dp),
+            tint = Color.Gray
+        )
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
@@ -75,6 +75,9 @@ fun RestaurantCard(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     SingleLineText(
+                        modifier = Modifier
+                            .weight(1f)
+                            .padding(end = 4.dp),
                         text = title,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Medium

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
@@ -40,10 +40,10 @@ fun RestaurantCard(
     dist: String,
     category: String,
     image: String,
+    modifier: Modifier = Modifier
 ) {
     Card(
-        modifier = Modifier
-            .width(300.dp),
+        modifier = modifier,
         elevation = CardDefaults.elevatedCardElevation(6.dp),
     ) {
         Row(

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/RestaurantCard.kt
@@ -1,13 +1,10 @@
-package kr.ksw.visitkorea.presentation.home.screen
+package kr.ksw.visitkorea.presentation.home.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -18,9 +15,11 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -35,26 +34,29 @@ import kr.ksw.visitkorea.presentation.component.SingleLineText
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
 @Composable
-fun CultureCard(
-    modifier: Modifier = Modifier,
-    ratio: Float = 0.7f,
+fun RestaurantCard(
     title: String,
     address: String,
+    dist: String,
+    category: String,
     image: String,
 ) {
-    Card (
-        modifier = modifier
-            .aspectRatio(ratio),
-        shape = RoundedCornerShape(24.dp),
-        elevation = CardDefaults.elevatedCardElevation(
-            defaultElevation = 4.dp
-        )
+    Card(
+        modifier = Modifier
+            .width(300.dp),
+        elevation = CardDefaults.elevatedCardElevation(6.dp),
     ) {
-        Column {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(Color.White)
+                .padding(10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             AsyncImage(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(1f)
+                    .size(88.dp)
+                    .clip(RoundedCornerShape(16.dp))
                     .background(color = Color.LightGray),
                 model = ImageRequest
                     .Builder(LocalContext.current)
@@ -66,17 +68,23 @@ fun CultureCard(
             )
             Column(
                 modifier = Modifier
-                    .fillMaxSize()
-                    .background(Color.White)
-                    .padding(horizontal = 8.dp),
-                verticalArrangement = Arrangement.Center
+                    .padding(start = 8.dp)
             ) {
-                SingleLineText(
-                    modifier = Modifier.padding(start = 2.dp),
-                    text = title,
-                    fontSize = 14.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    SingleLineText(
+                        text = title,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    Text(
+                        text = category,
+                        fontSize = 14.sp,
+                        color = Color.Gray
+                    )
+                }
                 Row(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
@@ -88,9 +96,13 @@ fun CultureCard(
                     )
                     SingleLineText(
                         text = address,
-                        fontSize = 12.sp,
+                        fontSize = 14.sp
                     )
                 }
+                SingleLineText(
+                    text = dist,
+                    fontSize = 12.sp
+                )
             }
         }
     }
@@ -98,16 +110,15 @@ fun CultureCard(
 
 @Composable
 @Preview(showBackground = true)
-fun CultureCardPreview() {
+fun RestaurantCardPreview() {
     VisitKoreaTheme {
-        Surface(
-            modifier = Modifier
-                .padding(20.dp)
-        ) {
-            CultureCard(
-                title = "문화시설",
-                address = "문화시설 주소",
-                image = "https://ksw"
+        Surface {
+            RestaurantCard(
+                "음식점",
+                "음식점 주소",
+                "188m",
+                "한식",
+                "https"
             )
         }
     }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/TouristSpotCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/component/TouristSpotCard.kt
@@ -1,4 +1,4 @@
-package kr.ksw.visitkorea.presentation.home.screen
+package kr.ksw.visitkorea.presentation.home.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
@@ -38,6 +38,9 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import coil.size.Size
+import kr.ksw.visitkorea.presentation.home.component.CultureCard
+import kr.ksw.visitkorea.presentation.home.component.RestaurantCard
+import kr.ksw.visitkorea.presentation.home.component.TouristSpotCard
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeState
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeViewModel
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
@@ -1,5 +1,6 @@
 package kr.ksw.visitkorea.presentation.home.screen
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -15,11 +16,14 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material.icons.outlined.LocationOn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -38,11 +42,15 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import coil.size.Size
+import kotlinx.coroutines.flow.collectLatest
 import kr.ksw.visitkorea.presentation.home.component.CultureCard
+import kr.ksw.visitkorea.presentation.home.component.MoreButton
 import kr.ksw.visitkorea.presentation.home.component.RestaurantCard
 import kr.ksw.visitkorea.presentation.home.component.TouristSpotCard
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeState
+import kr.ksw.visitkorea.presentation.home.viewmodel.HomeUiEffect
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeViewModel
+import kr.ksw.visitkorea.presentation.more.MoreActivity
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
 @Composable
@@ -50,14 +58,32 @@ fun HomeScreen(
     homeViewModel: HomeViewModel = hiltViewModel()
 ) {
     val homeState by homeViewModel.homeState.collectAsState()
+    val context = LocalContext.current
+    LaunchedEffect(homeViewModel.homeUiEffect) {
+        homeViewModel.homeUiEffect.collectLatest { effect ->
+            when(effect) {
+                is HomeUiEffect.StartHomeActivity -> {
+                    context.startActivity(Intent(
+                        context,
+                        MoreActivity::class.java
+                    ).apply {
+                        putExtra("contentTypeId", effect.contentTypeId)
+                    })
+                }
+            }
+        }
+    }
+
     HomeScreen(
-        homeState = homeState
+        homeState = homeState,
+        onMoreClick = homeViewModel::startMoreActivity
     )
 }
 
 @Composable
 fun HomeScreen(
-    homeState: HomeState
+    homeState: HomeState,
+    onMoreClick: (String) -> Unit
 ) {
     val scrollState = rememberScrollState()
     Surface {
@@ -125,15 +151,24 @@ fun HomeScreen(
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 16.dp)
+                    .padding(top = 16.dp, bottom = 20.dp)
             ) {
-                Text(
+                Row(
                     modifier = Modifier
-                        .padding(start = 16.dp, bottom = 20.dp),
-                    text = "관광지",
-                    fontSize = 22.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "관광지",
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    MoreButton {
+                        onMoreClick("12")
+                    }
+                }
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp)
@@ -158,13 +193,22 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .padding(top = 16.dp, bottom = 20.dp)
             ) {
-                Text(
+                Row(
                     modifier = Modifier
-                        .padding(start = 16.dp, bottom = 10.dp),
-                    text = "문화시설",
-                    fontSize = 22.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "문화시설",
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    MoreButton {
+                        onMoreClick("14")
+                    }
+                }
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp)
@@ -189,13 +233,22 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .padding(top = 16.dp, bottom = 20.dp)
             ) {
-                Text(
+                Row(
                     modifier = Modifier
-                        .padding(start = 16.dp, bottom = 10.dp),
-                    text = "레포츠",
-                    fontSize = 22.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "레포츠",
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    MoreButton {
+                        onMoreClick("28")
+                    }
+                }
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp)
@@ -220,13 +273,22 @@ fun HomeScreen(
                     .fillMaxWidth()
                     .padding(top = 16.dp, bottom = 20.dp)
             ) {
-                Text(
+                Row(
                     modifier = Modifier
-                        .padding(start = 16.dp, bottom = 10.dp),
-                    text = "음식점",
-                    fontSize = 22.sp,
-                    fontWeight = FontWeight.Medium
-                )
+                        .fillMaxWidth()
+                        .padding(start = 16.dp, end = 16.dp, bottom = 10.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text = "음식점",
+                        fontSize = 22.sp,
+                        fontWeight = FontWeight.Medium
+                    )
+                    MoreButton {
+                        onMoreClick("39")
+                    }
+                }
                 LazyRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
                     contentPadding = PaddingValues(horizontal = 16.dp)
@@ -257,7 +319,8 @@ fun HomeScreenPreview() {
         HomeScreen(
             homeState = HomeState(
                 mainImage = "https://tong.visitkorea.or.kr/cms/resource/11/3094511_image2_1.jpg"
-            )
+            ),
+            onMoreClick = {  }
         )
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -303,7 +304,8 @@ fun HomeScreen(
                             restaurant.address,
                             restaurant.dist,
                             restaurant.category,
-                            restaurant.firstImage
+                            restaurant.firstImage,
+                            Modifier.width(300.dp)
                         )
                     }
                 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/screen/HomeScreen.kt
@@ -44,6 +44,7 @@ import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import coil.size.Size
 import kotlinx.coroutines.flow.collectLatest
+import kr.ksw.visitkorea.presentation.common.ContentType
 import kr.ksw.visitkorea.presentation.home.component.CultureCard
 import kr.ksw.visitkorea.presentation.home.component.MoreButton
 import kr.ksw.visitkorea.presentation.home.component.RestaurantCard
@@ -51,6 +52,7 @@ import kr.ksw.visitkorea.presentation.home.component.TouristSpotCard
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeState
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeUiEffect
 import kr.ksw.visitkorea.presentation.home.viewmodel.HomeViewModel
+import kr.ksw.visitkorea.presentation.main.MainRoute
 import kr.ksw.visitkorea.presentation.more.MoreActivity
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
@@ -68,7 +70,7 @@ fun HomeScreen(
                         context,
                         MoreActivity::class.java
                     ).apply {
-                        putExtra("contentTypeId", effect.contentTypeId)
+                        putExtra("contentType", effect.contentType)
                     })
                 }
             }
@@ -84,7 +86,7 @@ fun HomeScreen(
 @Composable
 fun HomeScreen(
     homeState: HomeState,
-    onMoreClick: (String) -> Unit
+    onMoreClick: (ContentType) -> Unit
 ) {
     val scrollState = rememberScrollState()
     Surface {
@@ -167,7 +169,7 @@ fun HomeScreen(
                         fontWeight = FontWeight.Medium
                     )
                     MoreButton {
-                        onMoreClick("12")
+                        onMoreClick(ContentType.TOURIST)
                     }
                 }
                 LazyRow(
@@ -207,7 +209,7 @@ fun HomeScreen(
                         fontWeight = FontWeight.Medium
                     )
                     MoreButton {
-                        onMoreClick("14")
+                        onMoreClick(ContentType.CULTURE)
                     }
                 }
                 LazyRow(
@@ -247,7 +249,7 @@ fun HomeScreen(
                         fontWeight = FontWeight.Medium
                     )
                     MoreButton {
-                        onMoreClick("28")
+                        onMoreClick(ContentType.LEiSURE)
                     }
                 }
                 LazyRow(
@@ -287,7 +289,7 @@ fun HomeScreen(
                         fontWeight = FontWeight.Medium
                     )
                     MoreButton {
-                        onMoreClick("39")
+                        onMoreClick(ContentType.RESTAURANT)
                     }
                 }
                 LazyRow(

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeUiEffect.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeUiEffect.kt
@@ -1,0 +1,5 @@
+package kr.ksw.visitkorea.presentation.home.viewmodel
+
+sealed class HomeUiEffect {
+    data class StartHomeActivity(val contentTypeId: String) : HomeUiEffect()
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeUiEffect.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeUiEffect.kt
@@ -1,5 +1,7 @@
 package kr.ksw.visitkorea.presentation.home.viewmodel
 
+import kr.ksw.visitkorea.presentation.common.ContentType
+
 sealed class HomeUiEffect {
-    data class StartHomeActivity(val contentTypeId: String) : HomeUiEffect()
+    data class StartHomeActivity(val contentType: ContentType) : HomeUiEffect()
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeViewModel.kt
@@ -3,8 +3,11 @@ package kr.ksw.visitkorea.presentation.home.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -24,6 +27,10 @@ class HomeViewModel @Inject constructor(
     private val _homeState = MutableStateFlow(HomeState())
     val homeState: StateFlow<HomeState>
         get() = _homeState.asStateFlow()
+
+    private val _homeUiEffect = MutableSharedFlow<HomeUiEffect>(replay = 0)
+    val homeUiEffect: SharedFlow<HomeUiEffect>
+        get() = _homeUiEffect.asSharedFlow()
 
     init {
         getTouristSpot()
@@ -94,6 +101,12 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+        }
+    }
+
+    fun startMoreActivity(contentTypeId: String) {
+        viewModelScope.launch {
+            _homeUiEffect.emit(HomeUiEffect.StartHomeActivity(contentTypeId))
         }
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/home/viewmodel/HomeViewModel.kt
@@ -15,6 +15,7 @@ import kr.ksw.visitkorea.domain.usecase.home.GetCultureCenterForHomeUseCase
 import kr.ksw.visitkorea.domain.usecase.home.GetLeisureSportsForHomeUseCase
 import kr.ksw.visitkorea.domain.usecase.home.GetRestaurantForHomeUseCase
 import kr.ksw.visitkorea.domain.usecase.home.GetTouristSpotForHomeUseCase
+import kr.ksw.visitkorea.presentation.common.ContentType
 import javax.inject.Inject
 
 @HiltViewModel
@@ -104,9 +105,9 @@ class HomeViewModel @Inject constructor(
         }
     }
 
-    fun startMoreActivity(contentTypeId: String) {
+    fun startMoreActivity(contentType: ContentType) {
         viewModelScope.launch {
-            _homeUiEffect.emit(HomeUiEffect.StartHomeActivity(contentTypeId))
+            _homeUiEffect.emit(HomeUiEffect.StartHomeActivity(contentType))
         }
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/hotel/screen/HotelScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/hotel/screen/HotelScreen.kt
@@ -1,6 +1,5 @@
 package kr.ksw.visitkorea.presentation.hotel.screen
 
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -9,9 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyGridState
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,7 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import kr.ksw.visitkorea.domain.usecase.model.CommonCardModel
-import kr.ksw.visitkorea.presentation.home.screen.CultureCard
+import kr.ksw.visitkorea.presentation.home.component.CultureCard
 import kr.ksw.visitkorea.presentation.hotel.viewmodel.HotelViewModel
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/hotel/viewmodel/HotelViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/hotel/viewmodel/HotelViewModel.kt
@@ -40,7 +40,6 @@ class HotelViewModel @Inject constructor(
                         it.toCommonCardModel()
                     }
                 }.cachedIn(viewModelScope)
-
                 _hotelState.update {
                     it.copy(
                         hotelCardModelFlow = hotelCardModelFlow

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/main/MainNavHost.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.sp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import kr.ksw.visitkorea.presentation.festival.screen.FestivalScreen
 import kr.ksw.visitkorea.presentation.home.screen.HomeScreen
 import kr.ksw.visitkorea.presentation.hotel.screen.HotelScreen
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
@@ -32,12 +33,7 @@ fun MainNavHost(
             HotelScreen()
         }
         composable(route = MainRoute.EVENT.route) {
-            SampleScreen {
-                Text(
-                    text = "EVENT",
-                    fontSize = 32.sp
-                )
-            }
+            FestivalScreen()
         }
         composable(route = MainRoute.SEARCH.route) {
             SampleScreen {

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/MoreActivity.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/MoreActivity.kt
@@ -1,0 +1,30 @@
+package kr.ksw.visitkorea.presentation.more
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import dagger.hilt.android.AndroidEntryPoint
+import kr.ksw.visitkorea.presentation.more.screen.MoreScreen
+import kr.ksw.visitkorea.presentation.more.viewmodel.MoreViewModel
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@AndroidEntryPoint
+class MoreActivity : ComponentActivity() {
+    private val viewModel: MoreViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            VisitKoreaTheme {
+                MoreScreen(
+                    viewModel = viewModel,
+                    contentTypeId = intent.getStringExtra("contentTypeId") ?: ""
+                ) {
+                    finish()
+                }
+            }
+        }
+        viewModel.getMoreListByContentType(intent.getStringExtra("contentTypeId") ?: "")
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/MoreActivity.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/MoreActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import dagger.hilt.android.AndroidEntryPoint
+import kr.ksw.visitkorea.presentation.common.ContentType
 import kr.ksw.visitkorea.presentation.more.screen.MoreScreen
 import kr.ksw.visitkorea.presentation.more.viewmodel.MoreViewModel
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
@@ -15,16 +16,17 @@ class MoreActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val contentType = (intent.getSerializableExtra("contentType") as? ContentType) ?: ContentType.TOURIST
         setContent {
             VisitKoreaTheme {
                 MoreScreen(
                     viewModel = viewModel,
-                    contentTypeId = intent.getStringExtra("contentTypeId") ?: ""
+                    contentType = contentType
                 ) {
                     finish()
                 }
             }
         }
-        viewModel.getMoreListByContentType(intent.getStringExtra("contentTypeId") ?: "")
+        viewModel.getMoreListByContentType(contentType.contentTypeId)
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreScreenHeader.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreScreenHeader.kt
@@ -1,0 +1,67 @@
+package kr.ksw.visitkorea.presentation.more.component
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@Composable
+fun MoreScreenHeader(
+    title: String,
+    onBackButtonClick: () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                vertical = 4.dp
+            ),
+    ) {
+        IconButton(
+            onClick = onBackButtonClick
+        ) {
+            Icon(
+                Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                contentDescription = "Back Button",
+                modifier = Modifier
+                    .size(40.dp)
+                    .align(Alignment.CenterStart)
+            )
+        }
+        Text(
+            modifier = Modifier
+                .align(Alignment.Center),
+            text = title,
+            fontWeight = FontWeight.Medium,
+            fontSize = 24.sp
+        )
+    }
+}
+
+@Composable
+@Preview
+fun MoreScreenHeaderPreview() {
+    VisitKoreaTheme {
+        Surface {
+            MoreScreenHeader(
+                "관광지"
+            ) {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreTouristCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreTouristCard.kt
@@ -1,8 +1,136 @@
 package kr.ksw.visitkorea.presentation.more.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FavoriteBorder
+import androidx.compose.material.icons.outlined.LocationOn
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CardElevation
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import coil.compose.AsyncImage
+import coil.request.ImageRequest
+import coil.size.Size
+import kr.ksw.visitkorea.presentation.component.SingleLineText
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
 @Composable
-fun MoreTouristCard() {
+fun MoreTouristCard(
+    title: String,
+    address: String,
+    image: String,
+) {
+    Card(
+        modifier = Modifier
+            .aspectRatio(0.7f),
+        shape = RoundedCornerShape(20.dp),
+        elevation = CardDefaults.elevatedCardElevation(6.dp)
+    ) {
+        Box {
+            AsyncImage(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(color = Color.LightGray),
+                model = ImageRequest
+                    .Builder(LocalContext.current)
+                    .data(image)
+                    .size(Size.ORIGINAL)
+                    .build(),
+                contentDescription = "Tourist Card",
+                contentScale = ContentScale.Crop,
+            )
+            Icon(
+                Icons.Outlined.FavoriteBorder,
+                contentDescription = "Favorite Icon",
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(10.dp)
+                    .size(24.dp),
+                tint = Color.Red
+            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(10.dp)
+                    .align(Alignment.BottomCenter)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(Color.White)
+                    .padding(vertical = 6.dp, horizontal = 4.dp)
+            ) {
+                SingleLineText(
+                    modifier = Modifier
+                        .padding(start = 4.dp),
+                    text = title,
+                    fontWeight = FontWeight.Medium,
+                    fontSize = 14.sp,
+                    style = TextStyle(
+                        platformStyle = PlatformTextStyle(
+                            includeFontPadding = false
+                        )
+                    )
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Icon(
+                        modifier = Modifier
+                            .size(18.dp),
+                        imageVector = Icons.Outlined.LocationOn,
+                        contentDescription = null,
+                    )
+                    SingleLineText(
+                        modifier = Modifier.weight(1f),
+                        text = address,
+                        fontSize = 12.sp,
+                        style = TextStyle(
+                            platformStyle = PlatformTextStyle(
+                                includeFontPadding = false
+                            )
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
 
+@Composable
+@Preview(showBackground = true)
+fun MoreTouristCard() {
+    VisitKoreaTheme {
+        Surface {
+            MoreTouristCard(
+                "수원화성",
+                "수원시 장안구 OOO",
+                ""
+            )
+        }
+    }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreTouristCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/component/MoreTouristCard.kt
@@ -1,0 +1,8 @@
+package kr.ksw.visitkorea.presentation.more.component
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun MoreTouristCard() {
+
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/screen/MoreScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/screen/MoreScreen.kt
@@ -1,0 +1,100 @@
+package kr.ksw.visitkorea.presentation.more.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.ksw.visitkorea.R
+import kr.ksw.visitkorea.domain.usecase.model.MoreCardModel
+import kr.ksw.visitkorea.presentation.home.component.CultureCard
+import kr.ksw.visitkorea.presentation.more.component.MoreScreenHeader
+import kr.ksw.visitkorea.presentation.more.viewmodel.MoreViewModel
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@Composable
+fun MoreScreen(
+    viewModel: MoreViewModel,
+    contentTypeId: String,
+    onBackButtonClick: () -> Unit
+) {
+    val moreState by viewModel.moreState.collectAsState()
+    val moreCardModels = moreState.moreCardModelFlow.collectAsLazyPagingItems()
+    MoreScreen(
+        moreCardModels = moreCardModels,
+        contentTypeId,
+        onBackButtonClick
+    )
+}
+
+@Composable
+fun MoreScreen(
+    moreCardModels: LazyPagingItems<MoreCardModel>,
+    contentTypeId: String,
+    onBackButtonClick: () -> Unit
+) {
+    Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+        ) {
+            MoreScreenHeader(
+                title = stringResource(moreTitle(contentTypeId)),
+                onBackButtonClick = onBackButtonClick
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                contentPadding = PaddingValues(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp),
+            ) {
+                items(
+                    count = moreCardModels.itemCount,
+                    key = { index ->
+                        moreCardModels[index]?.contentId?.toInt() ?: index
+                    }
+                ) { index ->
+                    val hotel = moreCardModels[index]
+                    hotel?.run {
+                        CultureCard(
+                            title = hotel.title,
+                            address = hotel.address,
+                            image = hotel.firstImage
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun moreTitle(contentTypeId: String) = when(contentTypeId) {
+    "12" -> R.string.tourist_spot_title
+    "14" -> R.string.culture_center_title
+    "28" -> R.string.leisure_sports_title
+    else -> R.string.restaurant_title
+}
+
+@Composable
+@Preview(showBackground = true)
+fun MoreScreenPreview() {
+    VisitKoreaTheme {
+        MoreScreen(
+            viewModel = hiltViewModel(),
+            contentTypeId = "12"
+        ) { }
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/screen/MoreScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/screen/MoreScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -83,33 +84,20 @@ fun MoreScreen(
                 isRefreshing = isRefreshing,
                 onRefresh = onRefresh,
             ) {
-                LazyVerticalGrid(
-                    columns = GridCells.Fixed(2),
-                    contentPadding = PaddingValues(16.dp),
-                    horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalArrangement = Arrangement.spacedBy(16.dp),
-                ) {
-                    items(
-                        count = moreCardModels.itemCount,
-                        key = { index ->
-                            moreCardModels[index]?.contentId?.toInt() ?: index
-                        }
-                    ) { index ->
-                        val model = moreCardModels[index]
-                        model?.run {
-                            when(contentType) {
-                                ContentType.TOURIST -> MoreTouristCard(
-                                    title = title,
-                                    address = address,
-                                    image = firstImage
-                                )
-                                ContentType.CULTURE,
-                                ContentType.LEiSURE -> CultureCard(
-                                    title = title,
-                                    address = address,
-                                    image = firstImage
-                                )
-                                else -> RestaurantCard(
+                if(contentType == ContentType.RESTAURANT) {
+                    LazyColumn(
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                        contentPadding = PaddingValues(16.dp),
+                    ) {
+                        items(
+                            count = moreCardModels.itemCount,
+                            key = { index ->
+                                moreCardModels[index]?.contentId?.toInt() ?: index
+                            }
+                        ) { index ->
+                            val model = moreCardModels[index]
+                            model?.run {
+                                RestaurantCard(
                                     title = title,
                                     address = address,
                                     dist = dist,
@@ -117,6 +105,36 @@ fun MoreScreen(
                                     image = firstImage,
                                     modifier = Modifier.fillMaxWidth()
                                 )
+                            }
+                        }
+                    }
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Fixed(2),
+                        contentPadding = PaddingValues(16.dp),
+                        horizontalArrangement = Arrangement.spacedBy(10.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        items(
+                            count = moreCardModels.itemCount,
+                            key = { index ->
+                                moreCardModels[index]?.contentId?.toInt() ?: index
+                            }
+                        ) { index ->
+                            val model = moreCardModels[index]
+                            model?.run {
+                                when(contentType) {
+                                    ContentType.TOURIST -> MoreTouristCard(
+                                        title = title,
+                                        address = address,
+                                        image = firstImage
+                                    )
+                                    else -> CultureCard(
+                                        title = title,
+                                        address = address,
+                                        image = firstImage
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
@@ -8,5 +8,6 @@ import kr.ksw.visitkorea.domain.usecase.model.MoreCardModel
 
 @Immutable
 data class MoreState(
+    val isRefreshing: Boolean = true,
     val moreCardModelFlow: Flow<PagingData<MoreCardModel>> = emptyFlow(),
 )

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
@@ -1,0 +1,12 @@
+package kr.ksw.visitkorea.presentation.more.viewmodel
+
+import androidx.compose.runtime.Immutable
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kr.ksw.visitkorea.domain.usecase.model.MoreCardModel
+
+@Immutable
+data class MoreState(
+    val moreCardModelFlow: Flow<PagingData<MoreCardModel>> = emptyFlow(),
+)

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
@@ -28,6 +28,11 @@ class MoreViewModel @Inject constructor(
         contentTypeId: String,
         forceFetch: Boolean = false
     ) {
+        if(forceFetch) {
+            _moreState.update {
+                it.copy(isRefreshing = true)
+            }
+        }
         viewModelScope.launch {
             val moreListFlow = getMoreListUseCase(
                 forceFetch,
@@ -35,19 +40,24 @@ class MoreViewModel @Inject constructor(
                 "37.5678958128",
                 contentTypeId
             ).getOrNull()
-            if(moreListFlow != null) {
-                val moreCardModelFlow = moreListFlow.map { pagingData ->
-                    pagingData.map {
-                        it.toMoreCardModel()
-                    }
-                }.cachedIn(viewModelScope)
+            if(moreListFlow == null) {
+                // Toast Effect
                 _moreState.update {
-                    it.copy(
-                        moreCardModelFlow = moreCardModelFlow
-                    )
+                    it.copy(isRefreshing = false)
                 }
+                return@launch
+            }
+            val moreCardModelFlow = moreListFlow.map { pagingData ->
+                pagingData.map {
+                    it.toMoreCardModel()
+                }
+            }.cachedIn(viewModelScope)
+            _moreState.update {
+                it.copy(
+                    moreCardModelFlow = moreCardModelFlow,
+                    isRefreshing = false
+                )
             }
         }
     }
-
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.cachedIn
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -28,12 +29,14 @@ class MoreViewModel @Inject constructor(
         contentTypeId: String,
         forceFetch: Boolean = false
     ) {
-        if(forceFetch) {
-            _moreState.update {
-                it.copy(isRefreshing = true)
-            }
-        }
         viewModelScope.launch {
+            if(forceFetch) {
+                _moreState.update {
+                    it.copy(isRefreshing = true)
+                }
+                delay(500)
+            }
+
             val moreListFlow = getMoreListUseCase(
                 forceFetch,
                 "126.9817290217",

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
@@ -1,0 +1,53 @@
+package kr.ksw.visitkorea.presentation.more.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.map
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kr.ksw.visitkorea.R
+import kr.ksw.visitkorea.domain.usecase.mapper.toMoreCardModel
+import kr.ksw.visitkorea.domain.usecase.more.GetMoreListUseCase
+import javax.inject.Inject
+
+@HiltViewModel
+class MoreViewModel @Inject constructor(
+    private val getMoreListUseCase: GetMoreListUseCase
+): ViewModel() {
+    private val _moreState = MutableStateFlow(MoreState())
+    val moreState: StateFlow<MoreState>
+        get() = _moreState.asStateFlow()
+
+    fun getMoreListByContentType(
+        contentTypeId: String,
+        forceFetch: Boolean = false
+    ) {
+        viewModelScope.launch {
+            val moreListFlow = getMoreListUseCase(
+                forceFetch,
+                "126.9817290217",
+                "37.5678958128",
+                contentTypeId
+            ).getOrNull()
+            if(moreListFlow != null) {
+                val moreCardModelFlow = moreListFlow.map { pagingData ->
+                    pagingData.map {
+                        it.toMoreCardModel()
+                    }
+                }.cachedIn(viewModelScope)
+                _moreState.update {
+                    it.copy(
+                        moreCardModelFlow = moreCardModelFlow
+                    )
+                }
+            }
+        }
+    }
+
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,9 @@
     <string name="main_tab_event_title">행사</string>
     <string name="main_tab_search_title">검색</string>
     <string name="main_tab_favorite_title">즐겨찾기</string>
+
+    <string name="tourist_spot_title">관광지</string>
+    <string name="culture_center_title">문화시설</string>
+    <string name="leisure_sports_title">레포츠</string>
+    <string name="restaurant_title">음식점</string>
 </resources>


### PR DESCRIPTION
## 변경사항
- 전국 행사조회 API가 추가되었습니다.
- FestivalScreen 이 추가되었습니다.
- MoreScreen이 추가되었습니다.

## 멘토님께
- 이전에 작업한 로컬 브랜치 내용이라 추후 PR에서 좌표 기본값 및 PageSize 등 상수처리가 되어있지 않습니다.
- data class의 trailing comma도 추후 추가하였습니다.

## 동작화면
- 행사 탭

https://github.com/user-attachments/assets/6ad7f472-84d2-4778-86e5-658341cfabaa


- 더보기

https://github.com/user-attachments/assets/a9ed124e-2a42-41c8-bf0e-2c1c4d3a9052

