### PR TITLE
[#15] 검색화면 (SearchScreen) 구현

### DIFF
--- a/app/src/main/java/kr/ksw/visitkorea/data/di/DataModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/di/DataModule.kt
@@ -11,12 +11,15 @@ import kr.ksw.visitkorea.data.remote.api.AreaCodeApi
 import kr.ksw.visitkorea.data.remote.api.LocationBasedListApi
 import kr.ksw.visitkorea.data.remote.api.RetrofitInterceptor
 import kr.ksw.visitkorea.data.remote.api.SearchFestivalApi
+import kr.ksw.visitkorea.data.remote.api.SearchKeywordApi
 import kr.ksw.visitkorea.data.repository.AreaCodeRepository
 import kr.ksw.visitkorea.data.repository.AreaCodeRepositoryImpl
 import kr.ksw.visitkorea.data.repository.LocationBasedListRepository
 import kr.ksw.visitkorea.data.repository.LocationBasedListRepositoryImpl
 import kr.ksw.visitkorea.data.repository.SearchFestivalRepository
 import kr.ksw.visitkorea.data.repository.SearchFestivalRepositoryImpl
+import kr.ksw.visitkorea.data.repository.SearchKeywordRepository
+import kr.ksw.visitkorea.data.repository.SearchKeywordRepositoryImpl
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
@@ -84,5 +87,15 @@ object DataModule {
     @Singleton
     fun provideSearchFestivalRepository(searchFestivalApi: SearchFestivalApi): SearchFestivalRepository {
         return SearchFestivalRepositoryImpl(searchFestivalApi)
+    }
+
+    @Provides
+    @Singleton
+    fun provideSearchKeywordApi(retrofit: Retrofit): SearchKeywordApi = retrofit.create(SearchKeywordApi::class.java)
+
+    @Provides
+    @Singleton
+    fun provideSearchKeywordRepository(searchKeywordApi: SearchKeywordApi): SearchKeywordRepository {
+        return SearchKeywordRepositoryImpl(searchKeywordApi)
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchKeyWordPagingSource.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/paging/source/SearchKeyWordPagingSource.kt
@@ -1,0 +1,40 @@
+package kr.ksw.visitkorea.data.paging.source
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import kr.ksw.visitkorea.data.mapper.toItems
+import kr.ksw.visitkorea.data.remote.api.SearchKeywordApi
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+
+class SearchKeyWordPagingSource(
+    private val searchKeywordApi: SearchKeywordApi,
+    private val keyword: String
+) : PagingSource<Int, LocationBasedDTO>(){
+
+    override fun getRefreshKey(state: PagingState<Int, LocationBasedDTO>): Int? {
+        return state.anchorPosition?.let { anchor ->
+            val anchorPage = state.closestPageToPosition(anchor)
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, LocationBasedDTO> {
+        val page = params.key ?: 1
+        val loadSize = params.loadSize
+        val data = try {
+            searchKeywordApi.searchListByKeyword(
+                numOfRows = loadSize,
+                pageNo = page,
+                keyword = keyword
+            ).toItems()
+        } catch (e: Exception) {
+            emptyList()
+        }
+        return LoadResult.Page(
+            data = data,
+            prevKey = if(page == 1 || data.isEmpty()) null else page - 1,
+            nextKey = if(data.size == loadSize && data.isNotEmpty()) page + 1 else null
+        )
+    }
+
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/remote/api/SearchKeywordApi.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/remote/api/SearchKeywordApi.kt
@@ -1,0 +1,17 @@
+package kr.ksw.visitkorea.data.remote.api
+
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+import kr.ksw.visitkorea.data.remote.model.ApiResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface SearchKeywordApi {
+    @GET("searchKeyword1")
+    suspend fun searchListByKeyword(
+        @Query("arrange") arrange: String = "Q",
+        @Query("numOfRows") numOfRows: Int,
+        @Query("pageNo") pageNo: Int,
+        @Query("keyword") keyword: String,
+        @Query("contentTypeId") contentTypeId: String? = null
+    ): ApiResponse<LocationBasedDTO>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepository.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepository.kt
@@ -3,7 +3,7 @@ package kr.ksw.visitkorea.data.repository
 import kr.ksw.visitkorea.data.remote.dto.SearchFestivalDTO
 
 interface SearchFestivalRepository {
-    suspend operator fun invoke(
+    suspend fun searchFestival(
         numOfRows: Int,
         pageNo: Int,
         eventStartDate: String,

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchFestivalRepositoryImpl.kt
@@ -8,7 +8,7 @@ import javax.inject.Inject
 class SearchFestivalRepositoryImpl @Inject constructor(
     private val searchFestivalApi: SearchFestivalApi
 ): SearchFestivalRepository {
-    override suspend fun invoke(
+    override suspend fun searchFestival(
         numOfRows: Int,
         pageNo: Int,
         eventStartDate: String,

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchKeywordRepository.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchKeywordRepository.kt
@@ -1,0 +1,11 @@
+package kr.ksw.visitkorea.data.repository
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+
+interface SearchKeywordRepository {
+    suspend fun getListByKeyword(
+        keyword: String
+    ): Result<Flow<PagingData<LocationBasedDTO>>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchKeywordRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/SearchKeywordRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package kr.ksw.visitkorea.data.repository
+
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.PagingSource
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.paging.source.SearchKeyWordPagingSource
+import kr.ksw.visitkorea.data.remote.api.SearchKeywordApi
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+import javax.inject.Inject
+
+class SearchKeywordRepositoryImpl @Inject constructor(
+    private val searchKeywordApi: SearchKeywordApi
+) : SearchKeywordRepository {
+    private var pagingSource: PagingSource<Int, LocationBasedDTO>? = null
+
+    override suspend fun getListByKeyword(
+        keyword: String
+    ): Result<Flow<PagingData<LocationBasedDTO>>> = runCatching {
+        pagingSource?.run {
+            if(!invalid) {
+                invalidate()
+            }
+        }
+        Pager(
+            config = PagingConfig(
+                pageSize = 30,
+                initialLoadSize = 30
+            ),
+            pagingSourceFactory = {
+                SearchKeyWordPagingSource(
+                    searchKeywordApi,
+                    keyword,
+                ).also {
+                    pagingSource = it
+                }
+            }
+        ).flow
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/di/SearchModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/di/SearchModule.kt
@@ -1,0 +1,17 @@
+package kr.ksw.visitkorea.domain.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ActivityRetainedComponent
+import kr.ksw.visitkorea.domain.usecase.search.GetListByKeywordUseCase
+import kr.ksw.visitkorea.domain.usecase.search.GetListByKeywordUseCaseImpl
+
+@Module
+@InstallIn(ActivityRetainedComponent::class)
+abstract class SearchModule {
+    @Binds
+    abstract fun bindGetListByKeywordUseCase(
+        getListByKeywordUseCase: GetListByKeywordUseCaseImpl
+    ): GetListByKeywordUseCase
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/search/GetListByKeywordUseCase.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/search/GetListByKeywordUseCase.kt
@@ -1,0 +1,11 @@
+package kr.ksw.visitkorea.domain.usecase.search
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+
+interface GetListByKeywordUseCase {
+    suspend operator fun invoke(
+        keyword: String
+    ): Result<Flow<PagingData<LocationBasedDTO>>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/search/GetListByKeywordUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/search/GetListByKeywordUseCaseImpl.kt
@@ -1,0 +1,15 @@
+package kr.ksw.visitkorea.domain.usecase.search
+
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kr.ksw.visitkorea.data.remote.dto.LocationBasedDTO
+import kr.ksw.visitkorea.data.repository.SearchKeywordRepository
+import javax.inject.Inject
+
+class GetListByKeywordUseCaseImpl @Inject constructor(
+    private val searchKeywordRepository: SearchKeywordRepository
+): GetListByKeywordUseCase {
+    override suspend fun invoke(keyword: String): Result<Flow<PagingData<LocationBasedDTO>>> {
+        return searchKeywordRepository.getListByKeyword(keyword)
+    }
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/festival/component/FestivalCard.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/festival/component/FestivalCard.kt
@@ -51,17 +51,15 @@ fun FestivalCard(
         Box(
             modifier = Modifier
                 .background(Color.White)
-                .padding(
-                    top = 8.dp,
-                    start = 8.dp,
-                    end = 8.dp
-                )
         ) {
             AsyncImage(
                 modifier = Modifier
                     .fillMaxWidth()
                     .aspectRatio(2f)
-                    .clip(RoundedCornerShape(24.dp))
+                    .clip(RoundedCornerShape(
+                        topStart = 24.dp,
+                        topEnd = 24.dp
+                    ))
                     .background(color = Color.LightGray),
                 model = ImageRequest
                     .Builder(LocalContext.current)
@@ -115,38 +113,45 @@ fun FestivalCard(
                     letterSpacing = (-0.6).sp
                 )
             }
-            SingleLineText(
-                modifier = Modifier
-                    .padding(start = 16.dp, end = 16.dp, bottom = 10.dp)
-                    .align(Alignment.BottomEnd),
-                text = festival.title,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Medium,
-                color = Color.White
-            )
         }
-        Row(
+        Column(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.White)
-                .padding(
-                    top = 8.dp,
-                    start = 10.dp,
-                    end = 10.dp,
-                    bottom = 10.dp
-                ),
-            verticalAlignment = Alignment.CenterVertically
         ) {
-            Icon(
-                modifier = Modifier
-                    .size(20.dp),
-                imageVector = Icons.Outlined.LocationOn,
-                contentDescription = null,
-            )
             SingleLineText(
-                text = festival.address,
-                fontSize = 16.sp,
+                modifier = Modifier
+                    .padding(
+                        top = 8.dp,
+                        start = 10.dp,
+                        end = 10.dp,
+                        bottom = 4.dp
+                    ),
+                text = festival.title,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Medium,
             )
+            Row(
+                modifier = Modifier
+                    .padding(
+                        top = 8.dp,
+                        start = 10.dp,
+                        end = 10.dp,
+                        bottom = 10.dp
+                    ),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    modifier = Modifier
+                        .size(20.dp),
+                    imageVector = Icons.Outlined.LocationOn,
+                    contentDescription = null,
+                )
+                SingleLineText(
+                    text = festival.address,
+                    fontSize = 16.sp,
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/main/MainNavHost.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/main/MainNavHost.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import kr.ksw.visitkorea.presentation.festival.screen.FestivalScreen
 import kr.ksw.visitkorea.presentation.home.screen.HomeScreen
 import kr.ksw.visitkorea.presentation.hotel.screen.HotelScreen
+import kr.ksw.visitkorea.presentation.search.screen.SearchScreen
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
 
 @Composable
@@ -36,12 +37,7 @@ fun MainNavHost(
             FestivalScreen()
         }
         composable(route = MainRoute.SEARCH.route) {
-            SampleScreen {
-                Text(
-                    text = "SEARCH",
-                    fontSize = 32.sp
-                )
-            }
+            SearchScreen()
         }
         composable(route = MainRoute.FAVORITE.route) {
             SampleScreen {

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreState.kt
@@ -8,6 +8,6 @@ import kr.ksw.visitkorea.domain.usecase.model.MoreCardModel
 
 @Immutable
 data class MoreState(
-    val isRefreshing: Boolean = true,
+    val isRefreshing: Boolean = false,
     val moreCardModelFlow: Flow<PagingData<MoreCardModel>> = emptyFlow(),
 )

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/MoreViewModel.kt
@@ -12,7 +12,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kr.ksw.visitkorea.R
 import kr.ksw.visitkorea.domain.usecase.mapper.toMoreCardModel
 import kr.ksw.visitkorea.domain.usecase.more.GetMoreListUseCase
 import javax.inject.Inject
@@ -34,7 +33,6 @@ class MoreViewModel @Inject constructor(
                 _moreState.update {
                     it.copy(isRefreshing = true)
                 }
-                delay(500)
             }
 
             val moreListFlow = getMoreListUseCase(
@@ -43,6 +41,8 @@ class MoreViewModel @Inject constructor(
                 "37.5678958128",
                 contentTypeId
             ).getOrNull()
+            delay(300)
+
             if(moreListFlow == null) {
                 // Toast Effect
                 _moreState.update {

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/SearchActions.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/more/viewmodel/SearchActions.kt
@@ -1,0 +1,6 @@
+package kr.ksw.visitkorea.presentation.more.viewmodel
+
+sealed interface SearchActions {
+    data object SubmitSearchKeyword : SearchActions
+    data class UpdateSearchKeyword(val newKeyword: String) : SearchActions
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
@@ -1,0 +1,131 @@
+package kr.ksw.visitkorea.presentation.search.screen
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.SearchBar
+import androidx.compose.material3.SearchBarDefaults
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.paging.compose.collectAsLazyPagingItems
+import kr.ksw.visitkorea.presentation.home.component.CultureCard
+import kr.ksw.visitkorea.presentation.more.component.MoreScreenHeader
+import kr.ksw.visitkorea.presentation.more.viewmodel.SearchActions
+import kr.ksw.visitkorea.presentation.search.viewmodel.SearchState
+import kr.ksw.visitkorea.presentation.search.viewmodel.SearchViewModel
+import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
+
+@Composable
+fun SearchScreen(
+    viewModel: SearchViewModel = hiltViewModel(),
+) {
+    val searchState by viewModel.searchState.collectAsState()
+    SearchScreen(
+        searchState,
+        viewModel::onAction
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(
+    searchState: SearchState,
+    onAction: (SearchActions) -> Unit,
+) {
+    val searchCardModels = searchState.searchCardModelFlow.collectAsLazyPagingItems()
+    Surface {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            SearchBar(
+                inputField = {
+                    SearchBarDefaults.InputField(
+                        query = searchState.searchKeyword,
+                        onQueryChange = {
+                            onAction(SearchActions.UpdateSearchKeyword(it))
+                        },
+                        onSearch = {
+                            onAction(SearchActions.SubmitSearchKeyword)
+                        },
+                        expanded = false,
+                        onExpandedChange = {},
+                        placeholder = {
+                            Text(text = "검색어를 입력해주세요")
+                        },
+                        trailingIcon = {
+                            Icon(
+                                Icons.Default.Search,
+                                contentDescription = null
+                            )
+                        }
+                    )
+                },
+                expanded = false,
+                onExpandedChange = {}
+            ) {
+
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(2),
+                contentPadding = PaddingValues(16.dp),
+                horizontalArrangement = Arrangement.spacedBy(10.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                items(
+                    count = searchCardModels.itemCount,
+                    key = { index ->
+                        searchCardModels[index]?.contentId?.toInt() ?: index
+                    }
+                ) { index ->
+                    val model = searchCardModels[index]
+                    model?.run {
+                        CultureCard(
+                            modifier = Modifier.clickable {
+                                // Go to DetailActivity
+                            },
+                            title = title,
+                            address = address,
+                            image = firstImage
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+@Preview(showBackground = true)
+fun SearchScreenPreview() {
+    VisitKoreaTheme {
+        SearchScreen(
+            searchState = SearchState(),
+        ) {
+
+        }
+    }
+}
+

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
@@ -25,12 +26,15 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import kr.ksw.visitkorea.presentation.home.component.CultureCard
-import kr.ksw.visitkorea.presentation.more.viewmodel.SearchActions
+import kr.ksw.visitkorea.presentation.search.viewmodel.SearchActions
 import kr.ksw.visitkorea.presentation.search.viewmodel.SearchState
 import kr.ksw.visitkorea.presentation.search.viewmodel.SearchViewModel
 import kr.ksw.visitkorea.presentation.ui.theme.VisitKoreaTheme
@@ -53,15 +57,29 @@ fun SearchScreen(
     onAction: (SearchActions) -> Unit,
 ) {
     val searchCardModels = searchState.searchCardModelFlow.collectAsLazyPagingItems()
+    val focusManager = LocalFocusManager.current
+
     Surface {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .fillMaxSize()
+                .padding(horizontal = 16.dp),
         ) {
+            Spacer(modifier = Modifier.height(20.dp))
+            Text(
+                text = "검색",
+                fontSize = 32.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "키워드로 관광지를 찾아보세요!",
+                fontSize = 22.sp,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
             SearchBar(
                 modifier = Modifier
-                    .padding(horizontal = 16.dp),
+                    .fillMaxWidth(),
                 inputField = {
                     SearchBarDefaults.InputField(
                         query = searchState.searchKeyword,
@@ -70,6 +88,7 @@ fun SearchScreen(
                         },
                         onSearch = {
                             onAction(SearchActions.SubmitSearchKeyword)
+                            focusManager.clearFocus()
                         },
                         expanded = false,
                         onExpandedChange = {},
@@ -101,7 +120,7 @@ fun SearchScreen(
             } else {
                 LazyVerticalGrid(
                     columns = GridCells.Fixed(2),
-                    contentPadding = PaddingValues(16.dp),
+                    contentPadding = PaddingValues(vertical = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/screen/SearchScreen.kt
@@ -2,6 +2,7 @@ package kr.ksw.visitkorea.presentation.search.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.SearchBar
@@ -28,7 +30,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.collectAsLazyPagingItems
 import kr.ksw.visitkorea.presentation.home.component.CultureCard
-import kr.ksw.visitkorea.presentation.more.component.MoreScreenHeader
 import kr.ksw.visitkorea.presentation.more.viewmodel.SearchActions
 import kr.ksw.visitkorea.presentation.search.viewmodel.SearchState
 import kr.ksw.visitkorea.presentation.search.viewmodel.SearchViewModel
@@ -55,11 +56,12 @@ fun SearchScreen(
     Surface {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 16.dp),
+                .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             SearchBar(
+                modifier = Modifier
+                    .padding(horizontal = 16.dp),
                 inputField = {
                     SearchBarDefaults.InputField(
                         query = searchState.searchKeyword,
@@ -88,28 +90,38 @@ fun SearchScreen(
 
             }
             Spacer(modifier = Modifier.height(10.dp))
-            LazyVerticalGrid(
-                columns = GridCells.Fixed(2),
-                contentPadding = PaddingValues(16.dp),
-                horizontalArrangement = Arrangement.spacedBy(10.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp),
-            ) {
-                items(
-                    count = searchCardModels.itemCount,
-                    key = { index ->
-                        searchCardModels[index]?.contentId?.toInt() ?: index
-                    }
-                ) { index ->
-                    val model = searchCardModels[index]
-                    model?.run {
-                        CultureCard(
-                            modifier = Modifier.clickable {
-                                // Go to DetailActivity
-                            },
-                            title = title,
-                            address = address,
-                            image = firstImage
-                        )
+
+            if(searchState.isLoadingImages) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    contentPadding = PaddingValues(16.dp),
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
+                    verticalArrangement = Arrangement.spacedBy(16.dp),
+                ) {
+                    items(
+                        count = searchCardModels.itemCount,
+                        key = { index ->
+                            searchCardModels[index]?.contentId?.toInt() ?: index
+                        }
+                    ) { index ->
+                        val model = searchCardModels[index]
+                        model?.run {
+                            CultureCard(
+                                modifier = Modifier.clickable {
+                                    // Go to DetailActivity
+                                },
+                                title = title,
+                                address = address,
+                                image = firstImage
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchActions.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchActions.kt
@@ -1,4 +1,4 @@
-package kr.ksw.visitkorea.presentation.more.viewmodel
+package kr.ksw.visitkorea.presentation.search.viewmodel
 
 sealed interface SearchActions {
     data object SubmitSearchKeyword : SearchActions

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchState.kt
@@ -1,4 +1,14 @@
 package kr.ksw.visitkorea.presentation.search.viewmodel
 
-class SeachState {
-}
+import androidx.compose.runtime.Immutable
+import androidx.paging.PagingData
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kr.ksw.visitkorea.domain.usecase.model.CommonCardModel
+
+@Immutable
+data class SearchState(
+    val searchKeyword: String = "",
+    val isLoadingImages: Boolean = false,
+    val searchCardModelFlow: Flow<PagingData<CommonCardModel>> = emptyFlow(),
+)

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchState.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchState.kt
@@ -1,0 +1,4 @@
+package kr.ksw.visitkorea.presentation.search.viewmodel
+
+class SeachState {
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
@@ -6,6 +6,7 @@ import androidx.paging.cachedIn
 import androidx.paging.filter
 import androidx.paging.map
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -43,10 +44,23 @@ class SearchViewModel @Inject constructor(
 
     private fun getListByKeyword() {
         viewModelScope.launch {
+            _searchState.update {
+                it.copy(
+                    isLoadingImages = true
+                )
+            }
+
             val searchListFlow = getListByKeywordUseCase(
                 searchState.value.searchKeyword
             ).getOrNull()
+
+            delay(300)
             if(searchListFlow == null) {
+                _searchState.update {
+                    it.copy(
+                        isLoadingImages = false
+                    )
+                }
                 return@launch
             }
             val searchCardModelFlow = searchListFlow.map { pagingData ->
@@ -58,7 +72,8 @@ class SearchViewModel @Inject constructor(
             }.cachedIn(viewModelScope)
             _searchState.update {
                 it.copy(
-                    searchCardModelFlow = searchCardModelFlow
+                    searchCardModelFlow = searchCardModelFlow,
+                    isLoadingImages = false
                 )
             }
         }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
@@ -1,0 +1,4 @@
+package kr.ksw.visitkorea.presentation.search.viewmodel
+
+class SearchViewModel {
+}

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
@@ -1,4 +1,74 @@
 package kr.ksw.visitkorea.presentation.search.viewmodel
 
-class SearchViewModel {
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.cachedIn
+import androidx.paging.filter
+import androidx.paging.map
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kr.ksw.visitkorea.domain.usecase.mapper.toCommonCardModel
+import kr.ksw.visitkorea.domain.usecase.search.GetListByKeywordUseCase
+import kr.ksw.visitkorea.presentation.common.ContentType
+import kr.ksw.visitkorea.presentation.more.viewmodel.SearchActions
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor(
+    private val getListByKeywordUseCase: GetListByKeywordUseCase
+): ViewModel() {
+    private val _searchState: MutableStateFlow<SearchState> = MutableStateFlow(SearchState())
+    val searchState: StateFlow<SearchState>
+        get() = _searchState.asStateFlow()
+
+    fun onAction(action: SearchActions) {
+        when(action) {
+            is SearchActions.UpdateSearchKeyword -> {
+                _searchState.update {
+                    it.copy(
+                        searchKeyword = action.newKeyword
+                    )
+                }
+            }
+            SearchActions.SubmitSearchKeyword -> {
+                getListByKeyword()
+            }
+        }
+    }
+
+    private fun getListByKeyword() {
+        viewModelScope.launch {
+            val searchListFlow = getListByKeywordUseCase(
+                searchState.value.searchKeyword
+            ).getOrNull()
+            if(searchListFlow == null) {
+                return@launch
+            }
+            val searchCardModelFlow = searchListFlow.map { pagingData ->
+                pagingData.filter {
+                    contentTypeFilter(it.contentTypeId)
+                }.map {
+                    it.toCommonCardModel()
+                }
+            }.cachedIn(viewModelScope)
+            _searchState.update {
+                it.copy(
+                    searchCardModelFlow = searchCardModelFlow
+                )
+            }
+        }
+    }
+
+    private fun contentTypeFilter(contentType: String) = when(contentType) {
+        ContentType.CULTURE.contentTypeId,
+        ContentType.LEiSURE.contentTypeId,
+        ContentType.RESTAURANT.contentTypeId,
+        ContentType.TOURIST.contentTypeId -> true
+        else -> false
+    }
 }

--- a/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/presentation/search/viewmodel/SearchViewModel.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.launch
 import kr.ksw.visitkorea.domain.usecase.mapper.toCommonCardModel
 import kr.ksw.visitkorea.domain.usecase.search.GetListByKeywordUseCase
 import kr.ksw.visitkorea.presentation.common.ContentType
-import kr.ksw.visitkorea.presentation.more.viewmodel.SearchActions
 import javax.inject.Inject
 
 @HiltViewModel
@@ -36,7 +35,7 @@ class SearchViewModel @Inject constructor(
                     )
                 }
             }
-            SearchActions.SubmitSearchKeyword -> {
+            is SearchActions.SubmitSearchKeyword -> {
                 getListByKeyword()
             }
         }
@@ -49,12 +48,11 @@ class SearchViewModel @Inject constructor(
                     isLoadingImages = true
                 )
             }
-
             val searchListFlow = getListByKeywordUseCase(
                 searchState.value.searchKeyword
             ).getOrNull()
-
             delay(300)
+
             if(searchListFlow == null) {
                 _searchState.update {
                     it.copy(


### PR DESCRIPTION
## 변경사항
- SearchKeywordApi(키워드 검색 서비스)와 Repository, PagingSource가 추가되었습니다.
- GetListByKeywordUseCase가 추가되었습니다.
- SearchScreen이 추가되었습니다.

## 멘토님께
- ViewModel에서 Actions와 State를 분리하여 구현하였습니다.

## 동작화면

https://github.com/user-attachments/assets/9ef9e38c-a925-4c56-b316-a299a173489b

