### PR TITLE
[#25] 반복정보(객실정보) API 추가

### DIFF
--- a/app/src/main/java/kr/ksw/visitkorea/data/remote/api/DetailApi.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/remote/api/DetailApi.kt
@@ -2,6 +2,7 @@ package kr.ksw.visitkorea.data.remote.api
 
 import kr.ksw.visitkorea.data.remote.dto.DetailCommonDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailImageDTO
+import kr.ksw.visitkorea.data.remote.dto.DetailInfoDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailIntroDTO
 import kr.ksw.visitkorea.data.remote.model.ApiResponse
 import retrofit2.http.GET
@@ -23,9 +24,9 @@ interface DetailApi {
 
     @GET("detailInfo1")
     suspend fun getDetailInfo(
-        @Query("contentId") contentId: Int,
-        @Query("contentTypeId") contentTypeId: Int
-    )
+        @Query("contentId") contentId: String,
+        @Query("contentTypeId") contentTypeId: String = "32"
+    ): ApiResponse<DetailInfoDTO>
 
     @GET("detailImage1")
     suspend fun getDetailImage(

--- a/app/src/main/java/kr/ksw/visitkorea/data/remote/dto/DetailInfoDTO.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/remote/dto/DetailInfoDTO.kt
@@ -1,0 +1,46 @@
+package kr.ksw.visitkorea.data.remote.dto
+
+import com.google.gson.annotations.SerializedName
+
+data class DetailInfoDTO (
+    @SerializedName("roomtitle")
+    val roomTitle: String,
+    @SerializedName("roomsize1")
+    val roomSize: String,
+    @SerializedName("roomsize2")
+    val roomSize2: String,
+    @SerializedName("roombasecount")
+    val roomBaseCount: String,
+    @SerializedName("roommaxcount")
+    val roomMaxCount: String,
+    @SerializedName("roomoffseasonminfee1")
+    val roomOffSeasonMinFee1: String, // 비수기주중최소
+    @SerializedName("roomoffseasonminfee2")
+    val roomoffseasonminfee2: String, // 비수기주말최소
+    @SerializedName("roompeakseasonminfee1")
+    val roomPeakSeasonMinfee1: String, // 성수기주중최소
+    @SerializedName("roompeakseasonminfee2")
+    val roomPeakSeasonMinfee2: String, // 성수기주말최소
+    @SerializedName("roombathfacility")
+    val roomBathFacility: String,
+    @SerializedName("roomtv")
+    val roomTv: String,
+    @SerializedName("roompc")
+    val roomPc: String,
+    @SerializedName("roominternet")
+    val roomInternet: String,
+    @SerializedName("roomrefrigerator")
+    val roomRefrigerator: String,
+    @SerializedName("roomhairdryer")
+    val roomHairdryer: String,
+    @SerializedName("roomimg1")
+    val roomImg1: String,
+    @SerializedName("roomimg2")
+    val roomImg2: String,
+    @SerializedName("roomimg3")
+    val roomImg3: String,
+    @SerializedName("roomimg4")
+    val roomImg4: String,
+    @SerializedName("roomimg5")
+    val roomImg5: String,
+)

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/DetailRepository.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/DetailRepository.kt
@@ -2,6 +2,7 @@ package kr.ksw.visitkorea.data.repository
 
 import kr.ksw.visitkorea.data.remote.dto.DetailCommonDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailImageDTO
+import kr.ksw.visitkorea.data.remote.dto.DetailInfoDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailIntroDTO
 
 interface DetailRepository {
@@ -11,11 +12,15 @@ interface DetailRepository {
 
     suspend fun getDetailIntro(
         contentId: String,
-        contentTypeId: String
+        contentTypeId: String,
     ): Result<DetailIntroDTO>
+
+    suspend fun getDetailInfo(
+        contentId: String,
+    ): Result<List<DetailInfoDTO>>
 
     suspend fun getDetailImage(
         contentId: String,
-        imageYN: String
+        imageYN: String,
     ): Result<List<DetailImageDTO>>
 }

--- a/app/src/main/java/kr/ksw/visitkorea/data/repository/DetailRepositoryImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/data/repository/DetailRepositoryImpl.kt
@@ -4,6 +4,7 @@ import kr.ksw.visitkorea.data.mapper.toItems
 import kr.ksw.visitkorea.data.remote.api.DetailApi
 import kr.ksw.visitkorea.data.remote.dto.DetailCommonDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailImageDTO
+import kr.ksw.visitkorea.data.remote.dto.DetailInfoDTO
 import kr.ksw.visitkorea.data.remote.dto.DetailIntroDTO
 import javax.inject.Inject
 
@@ -26,6 +27,14 @@ class DetailRepositoryImpl @Inject constructor(
             contentId = contentId,
             contentTypeId = contentTypeId
         ).toItems().first()
+    }
+
+    override suspend fun getDetailInfo(
+        contentId: String
+    ): Result<List<DetailInfoDTO>> = runCatching {
+        detailApi.getDetailInfo(
+            contentId
+        ).toItems()
     }
 
     override suspend fun getDetailImage(

--- a/app/src/main/java/kr/ksw/visitkorea/domain/di/DetailModule.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/di/DetailModule.kt
@@ -8,6 +8,8 @@ import kr.ksw.visitkorea.domain.usecase.detail.GetDetailCommonUseCase
 import kr.ksw.visitkorea.domain.usecase.detail.GetDetailCommonUseCaseImpl
 import kr.ksw.visitkorea.domain.usecase.detail.GetDetailImageUseCase
 import kr.ksw.visitkorea.domain.usecase.detail.GetDetailImageUseCaseUseCaseImpl
+import kr.ksw.visitkorea.domain.usecase.detail.GetDetailInfoUseCase
+import kr.ksw.visitkorea.domain.usecase.detail.GetDetailInfoUseCaseImpl
 import kr.ksw.visitkorea.domain.usecase.detail.GetDetailIntroUseCase
 import kr.ksw.visitkorea.domain.usecase.detail.GetDetailIntroUseCaseImpl
 
@@ -28,4 +30,9 @@ abstract class DetailModule {
     abstract fun bindGetDetailImageUseCase(
         getDetailImageUseCase: GetDetailImageUseCaseUseCaseImpl
     ): GetDetailImageUseCase
+
+    @Binds
+    abstract fun bindGetDetailInfoUseCase(
+        getDetailInfoUseCase: GetDetailInfoUseCaseImpl
+    ): GetDetailInfoUseCase
 }

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/detail/GetDetailInfoUseCase.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/detail/GetDetailInfoUseCase.kt
@@ -1,0 +1,9 @@
+package kr.ksw.visitkorea.domain.usecase.detail
+
+import kr.ksw.visitkorea.data.remote.dto.DetailInfoDTO
+
+interface GetDetailInfoUseCase {
+    suspend operator fun invoke(
+        contentId: String
+    ): Result<List<DetailInfoDTO>>
+}

--- a/app/src/main/java/kr/ksw/visitkorea/domain/usecase/detail/GetDetailInfoUseCaseImpl.kt
+++ b/app/src/main/java/kr/ksw/visitkorea/domain/usecase/detail/GetDetailInfoUseCaseImpl.kt
@@ -1,0 +1,17 @@
+package kr.ksw.visitkorea.domain.usecase.detail
+
+import kr.ksw.visitkorea.data.remote.dto.DetailInfoDTO
+import kr.ksw.visitkorea.data.repository.DetailRepository
+import javax.inject.Inject
+
+class GetDetailInfoUseCaseImpl @Inject constructor(
+    private val detailRepository: DetailRepository
+) : GetDetailInfoUseCase {
+    override suspend fun invoke(
+        contentId: String
+    ): Result<List<DetailInfoDTO>> {
+        return detailRepository.getDetailInfo(
+            contentId = contentId
+        )
+    }
+}


### PR DESCRIPTION
## 변경사항
- `DetailInfoDTO`가 추가되었습니다.
- `GetDetailInfoUseCase`가 추가되었습니다.
- `DetailRepository`에 `getDetailInfo `가 추가되었습니다.

## 멘토님께
- `DetailApi`의 `getDetailInfo `안에있는 `contentTypeId`의 기본값이 하드코딩 되어있는데, 추후 상수로 변경될 예정입니다.